### PR TITLE
Add support for passing the http client timeout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -14,6 +15,7 @@ var (
 	cfgFile         string
 	baseDir         string
 	httpHeaders     []string
+	httpTimeout     time.Duration
 	encoded         bool
 	encryptionKey   string
 )

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"os"
+	"time"
 
 	"github.com/YaleUniversity/deco/control"
 
@@ -27,7 +28,7 @@ control file is specified, the default '/var/run/secrets/deco.json' is assumed.`
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		var c control.Configuration
-		if err := c.Read(controlLocation, httpHeaders, encoded); err != nil {
+		if err := c.Read(controlLocation, httpHeaders, httpTimeout, encoded); err != nil {
 			Logger.Println("[ERROR] Unable to validate control file.", err)
 			os.Exit(1)
 		}
@@ -49,5 +50,6 @@ control file is specified, the default '/var/run/secrets/deco.json' is assumed.`
 func init() {
 	runCmd.Flags().BoolVarP(&encoded, "encoded", "e", false, "Control file is base64 encoded")
 	runCmd.Flags().StringArrayVarP(&httpHeaders, "header", "H", []string{}, "Pass a custom header to server")
+	runCmd.Flags().DurationVarP(&httpTimeout, "timeout", "T", 15*time.Second, "Set the HTTP request timeout")
 	RootCmd.AddCommand(runCmd)
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/YaleUniversity/deco/control"
 	"github.com/spf13/cobra"
@@ -28,7 +29,7 @@ control file is specified, the default '/var/run/secrets/deco.json' is assumed.`
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		var c control.Configuration
-		if err := c.Read(controlLocation, httpHeaders, encoded); err != nil {
+		if err := c.Read(controlLocation, httpHeaders, httpTimeout, encoded); err != nil {
 			Logger.Println("[ERROR] Unable to read control file.", err)
 			os.Exit(1)
 		}
@@ -47,5 +48,6 @@ control file is specified, the default '/var/run/secrets/deco.json' is assumed.`
 func init() {
 	showCmd.Flags().BoolVarP(&encoded, "encoded", "e", false, "Control file is base64 encoded")
 	showCmd.Flags().StringArrayVarP(&httpHeaders, "header", "H", []string{}, "Pass a custom header to server")
+	showCmd.Flags().DurationVarP(&httpTimeout, "timeout", "T", 15*time.Second, "Set the HTTP request timeout")
 	RootCmd.AddCommand(showCmd)
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"os"
+	"time"
 
 	"github.com/YaleUniversity/deco/control"
 
@@ -27,7 +28,7 @@ control file is specified, the default '/var/run/secrets/deco.json' is assumed.`
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		var c control.Configuration
-		if err := c.Read(controlLocation, httpHeaders, encoded); err != nil {
+		if err := c.Read(controlLocation, httpHeaders, httpTimeout, encoded); err != nil {
 			Logger.Println("[ERROR] Unable to validate control file.", err)
 			os.Exit(1)
 		}
@@ -39,5 +40,6 @@ control file is specified, the default '/var/run/secrets/deco.json' is assumed.`
 func init() {
 	validateCmd.Flags().BoolVarP(&encoded, "encoded", "e", false, "Control file is base64 encoded")
 	validateCmd.Flags().StringArrayVarP(&httpHeaders, "header", "H", []string{}, "Pass a custom header to server")
+	validateCmd.Flags().DurationVarP(&httpTimeout, "timeout", "T", 15*time.Second, "Set the HTTP request timeout")
 	RootCmd.AddCommand(validateCmd)
 }

--- a/control/control.go
+++ b/control/control.go
@@ -80,14 +80,14 @@ func (f *Filter) UnmarshalJSON(b []byte) error {
 }
 
 // Get fetches the control from a location and returns a io.ReadCloser
-func Get(location string, headers []string) (io.ReadCloser, error) {
+func Get(location string, headers []string, timeout time.Duration) (io.ReadCloser, error) {
 	u, err := url.ParseRequestURI(location)
 	if err == nil {
 		if u.Scheme == "http" || u.Scheme == "https" {
 			Logger.Println("[INFO] Fetching control from URL", location)
 
 			var client = &http.Client{
-				Timeout: time.Second * 10,
+				Timeout: timeout,
 			}
 
 			req, err := http.NewRequest(http.MethodGet, location, nil)
@@ -136,8 +136,8 @@ func Get(location string, headers []string) (io.ReadCloser, error) {
 }
 
 // Read reads in the configuration and returns the object
-func (c *Configuration) Read(location string, headers []string, encoded bool) error {
-	r, err := Get(location, headers)
+func (c *Configuration) Read(location string, headers []string, timeout time.Duration, encoded bool) error {
+	r, err := Get(location, headers, timeout)
 	if err != nil {
 		return err
 	}

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/YaleUniversity/deco/control"
 )
@@ -52,7 +53,7 @@ func TestReadFile(t *testing.T) {
 
 		filename := testFile.Name()
 		var actual control.Configuration
-		if err := actual.Read(filename, []string{}, e); err != nil {
+		if err := actual.Read(filename, []string{}, 10*time.Second, e); err != nil {
 			t.Errorf("failed to read config: %s", err)
 		}
 
@@ -117,7 +118,7 @@ func TestReadURL(t *testing.T) {
 	defer ts.Close()
 
 	var actual control.Configuration
-	err := actual.Read(ts.URL, []string{"foo=bar", "biz=baz"}, false)
+	err := actual.Read(ts.URL, []string{"foo=bar", "biz=baz"}, 10*time.Second, false)
 	if err != nil {
 		t.Errorf("Expected to successfully read for test URL")
 	}


### PR DESCRIPTION
This adds support for overriding the HTTP client timeout for HTTP requests done by deco.